### PR TITLE
Undefined inputState exception

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -2,7 +2,7 @@ import Immutable from 'seamless-immutable';
 
 export default function combineReducers(reducers) {
   let reducerKeys = Object.keys(reducers);
-  return (inputState, action) => {
+  return (inputState=Immutable({}), action) => {
     return Immutable(reducerKeys.reduce((reducersObject, reducerName) => {
       let reducer = reducers[reducerName];
       let reducerState = inputState[reducerName];


### PR DESCRIPTION
Fixed error on undefined inputState. Gave inputState the Immutable  equivalent default to the regular combineReducers' empty dictionary default.
