### PR TITLE
Add check for inputState being defined

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -5,7 +5,7 @@ export default function combineReducers(reducers) {
   return (inputState, action) => {
     return Immutable(reducerKeys.reduce((reducersObject, reducerName) => {
       let reducer = reducers[reducerName];
-      let reducerState = inputState[reducerName];
+      let reducerState = inputState && inputState[reducerName];
       reducersObject[reducerName] = reducer(reducerState, action);
       return reducersObject;
     }, {}));


### PR DESCRIPTION
Without this check nesting combineReducers fails. I think this is possible with other implementations of combineReducers. For example I would like to do something like:

```
let reducers = combineReducers({
  auth: combineReducer({login: loginReducer, token: tokenReducer}),
  app: combineReducer({part1: part1Reducer, part2: part2Reducer}),
  ...
})
```

To produce state like:

```
{ 
  auth: {login: { }, token: { }})
  app: {part1: { }, part2: { })
  ...
}
```
