### PR TITLE
Make combineReducers idempotent

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -3,11 +3,14 @@ import Immutable from 'seamless-immutable';
 export default function combineReducers(reducers) {
   let reducerKeys = Object.keys(reducers);
   return (inputState=Immutable({}), action) => {
-    return Immutable(reducerKeys.reduce((reducersObject, reducerName) => {
+    let newState = Immutable(inputState);
+
+    reducerKeys.forEach(reducerName => {
       let reducer = reducers[reducerName];
       let reducerState = inputState[reducerName];
-      reducersObject[reducerName] = reducer(reducerState, action);
-      return reducersObject;
-    }, {}));
+      newState = newState.set(reducerName, reducer(reducerState, action));
+    });
+
+    return newState;
   }
 }

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import Immutable from 'seamless-immutable';
 import combineReducers from '../src/combineReducers';
 
 describe('combineReducers', () => {
@@ -14,5 +15,17 @@ describe('combineReducers', () => {
     expect(s1).to.eql({ counter: 1, stack: [] })
     const s2 = reducer(s1, { type: 'push', value: 'a' })
     expect(s2).to.eql({ counter: 1, stack: [ 'a' ] })
+  })
+
+  it('returns the same object instance if no state has changed', () => {
+    const reducer = combineReducers({
+      doNothing1: state => state || Immutable({ hello: "world" }),
+      doNothing2: state => state || Immutable({ one: 2 })
+    })
+
+    const s1 = reducer(Immutable({}), { type: "test1" });
+    const s2 = reducer(s1, { type: "test2" });
+
+    expect(s1).to.equal(s2);
   })
 })


### PR DESCRIPTION
I've been using your library for a little while now in combination with [reselect](https://github.com/reactjs/reselect) and have really found it useful. However, I noticed after a little while that my reselect selectors were firing for different parts of the state tree even though those parts did not change. I investigated a little bit and found that the `combineReducers` here is returning a new `Immutable` object no matter what the child reducers are doing.

I added a test case to illustrate what is happening and updated the implementation to not unnecessarily create new `Immutable` objects. For my code, this has improved performance since, given an action, my selectors only fire for the part of the state tree that is different.
