### PR TITLE
Remove babel setting in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,6 @@
     "prepublish": "npm run build",
     "test": "mocha --compilers js:babel-core/register --recursive ./test"
   },
-  "babel": {
-    "presets": [
-      "es2015"
-    ]
-  },
   "keywords": [
     "javascript",
     "redux",


### PR DESCRIPTION
babel setting in package.json causes TransformError in react-native and expo... many repo do not put the babel setting in package.json