### PR TITLE
Use Array.reduce to avoid using let variables

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -1,16 +1,9 @@
 import Immutable from 'seamless-immutable';
 
 export default function combineReducers(reducers) {
-  let reducerKeys = Object.keys(reducers);
-  return (inputState=Immutable({}), action) => {
-    let newState = Immutable(inputState);
-
-    reducerKeys.forEach(reducerName => {
-      let reducer = reducers[reducerName];
-      let reducerState = inputState[reducerName];
-      newState = newState.set(reducerName, reducer(reducerState, action));
-    });
-
-    return newState;
-  }
+  return (state=Immutable({}), action) => Object.keys(reducers)
+    .reduce(
+      (iState, key) => iState.set(key, reducers[key](state[key], action)),
+      Immutable(state)
+    )
 }


### PR DESCRIPTION
Using `let` kind of goes in the opposite direction of using Immutable stuff.
We can get away with a more functional approach :)