### PR TITLE
Add state and reducer validation and more tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "react-router-redux": "^4.0.0",
-    "seamless-immutable": "^6.1.0"
+    "seamless-immutable": "^7.1.2"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -1,9 +1,66 @@
 import Immutable from 'seamless-immutable';
+import {
+  assertReducerShape,
+  getUndefinedStateError,
+  getNoValidReducersError,
+  getNotSupportedTypeAsReducerError,
+  getPossibleUnexpectedStateShapeWarning
+} from './utils/combineReducersValidation'
 
 export default function combineReducers(reducers) {
-  return (state=Immutable({}), action) => Object.keys(reducers)
-    .reduce(
-      (iState, key) => iState.set(key, reducers[key](state[key], action)),
-      Immutable(state)
-    )
+  // Validate reducers.
+  const validReducers = Object.keys(reducers).reduce((accum, key) => {
+    // A reducer must be a function.
+    if (typeof reducers[key] !== 'function') {
+      if (process.env.NODE_ENV !== 'production') {
+        const errorMessage = getNotSupportedTypeAsReducerError(reducers, key)
+        throw new Error(errorMessage)
+      }
+      return accum
+    }
+
+    return accum.set(key, reducers[key])
+  }, Immutable({}))
+
+  const validReducerKeys = Object.keys(validReducers)
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (validReducerKeys.length === 0) {
+      const errorMessage = getNoValidReducersError()
+      throw new Error(errorMessage)
+    }
+  }
+
+  let shapeAssertionError
+  try {
+    assertReducerShape(validReducers)
+  } catch (e) {
+    shapeAssertionError = e
+  }
+
+  return function combination(state = Immutable({}), action) {
+    if (shapeAssertionError) {
+      throw new Error(shapeAssertionError)
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      const warningMessage = getPossibleUnexpectedStateShapeWarning(state, validReducers, action)
+      if (warningMessage) {
+        // eslint-disable-next-line no-console
+        console.tron ? console.tron.warn(warningMessage) : console.warn(warningMessage)
+      }
+    }
+
+    return validReducerKeys.reduce((nextState, key) => {
+      const nextDomainState = validReducers[key](state[key], action)
+
+      // Validate the next state; it cannot be undefined.
+      if (typeof nextDomainState === 'undefined') {
+        const errorMessage = getUndefinedStateError(key, action)
+        throw new Error(errorMessage)
+      }
+
+      return nextState.set(key, nextDomainState)
+    }, Immutable(state))
+  }
 }

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -47,7 +47,7 @@ export default function combineReducers(reducers) {
       const warningMessage = getPossibleUnexpectedStateShapeWarning(state, validReducers, action)
       if (warningMessage) {
         // eslint-disable-next-line no-console
-        console.tron ? console.tron.warn(warningMessage) : console.warn(warningMessage)
+        console.warn(warningMessage)
       }
     }
 

--- a/src/utils/combineReducersValidation.js
+++ b/src/utils/combineReducersValidation.js
@@ -1,0 +1,79 @@
+import Immutable from 'seamless-immutable'
+
+const REDUX_INIT_ACTION_TYPE = '@@redux/INIT'
+
+export function getUndefinedStateError (reducerKey, action) {
+  const actionType = action && action.type ? `"${action.type}"` : 'an'
+
+  return (
+    `Reducer "${reducerKey}" returned undefined when handling ${actionType} ` +
+    `action. To ignore an action, you must explicitly return the previous state.`
+  )
+}
+
+export function getNoValidReducersError () {
+  return (
+    'Store does not have a valid reducer. Make sure the argument passed ' +
+    'to combineReducers is an object whose values are reducers.'
+  )
+}
+
+export function getNotSupportedTypeAsReducerError (reducers, reducerKey) {
+  return (
+    `"${typeof reducers[reducerKey]}" is not a supported type for reducer "${reducerKey}". ` +
+    'A reducer must be a function.'
+  )
+}
+
+export function getPossibleUnexpectedStateShapeWarning (state, reducers, action) {
+  const reducerKeys = Object.keys(reducers)
+  const stateName = action && action.type === REDUX_INIT_ACTION_TYPE
+    ? 'preloadedState argument passed to createStore'
+    : 'previous state received by the reducer'
+
+  if (!Immutable.isImmutable(state)) {
+    return (
+      `The ${stateName} is of an unexpected type. Expected state to be an instance of a ` +
+      `Seamless Immutable object with the following properties: "${reducerKeys.join('", "')}".`
+    )
+  }
+
+  const unexpectedKeys = Object.keys(state).filter(key => !reducers.hasOwnProperty(key))
+
+  if (unexpectedKeys.length > 0) {
+    return (
+      `Unexpected ${unexpectedKeys.length > 1 ? 'keys' : 'key'} "${unexpectedKeys.join('", "')}" ` +
+      `found in ${stateName}. Expected to find one of the known reducer keys instead: ` +
+      `"${reducerKeys.join('", "')}". Unexpected keys will be ignored.`
+    )
+  }
+}
+
+export function assertReducerShape (reducers) {
+  Object.keys(reducers).forEach(key => {
+    const reducer = reducers[key]
+    const initialState = reducer(undefined, { type: REDUX_INIT_ACTION_TYPE })
+
+    if (typeof initialState === 'undefined') {
+      throw new Error(
+        `Reducer "${key}" returned undefined during initialization. ` +
+        `If the state passed to the reducer is undefined, you must ` +
+        `explicitly return the initial state. The initial state may ` +
+        `not be undefined. If you don't want to set a value for this reducer, ` +
+        `you can use null instead of undefined.`
+      )
+    }
+
+    const type = '@@redux/PROBE_UNKNOWN_ACTION_' + Math.random().toString(36).substring(7).split('').join('.')
+    if (typeof reducer(undefined, { type }) === 'undefined') {
+      throw new Error(
+        `Reducer "${key}" returned undefined when probed with a random type. ` +
+        `Don't try to handle ${REDUX_INIT_ACTION_TYPE} or other actions in "redux/*" ` +
+        `namespace. They are considered private. Instead, you must return the ` +
+        `current state for any unknown actions, unless it is undefined, ` +
+        `in which case you must return the initial state, regardless of the ` +
+        `action type. The initial state may not be undefined, but can be null.`
+      )
+    }
+  })
+}

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -11,7 +11,7 @@ describe('combineReducers', () => {
       action.type === 'push' ? [ ...state, action.value ] : state
     })
 
-    const s1 = reducer({}, { type: 'increment' })
+    const s1 = reducer(Immutable({}), { type: 'increment' })
     expect(s1).to.eql({ counter: 1, stack: [] })
     const s2 = reducer(s1, { type: 'push', value: 'a' })
     expect(s2).to.eql({ counter: 1, stack: [ 'a' ] })
@@ -27,5 +27,173 @@ describe('combineReducers', () => {
     const s2 = reducer(s1, { type: "test2" });
 
     expect(s1).to.equal(s2);
+  })
+
+  it('maintains referential equality if the reducers it is combining do', () => {
+    const reducer = combineReducers({
+      child1 (state = {}) {
+        return state
+      },
+      child2 (state = {}) {
+        return state
+      },
+      child3 (state = {}) {
+        return state
+      }
+    })
+
+    const initialState = reducer(Immutable({}), '@@INIT')
+    expect(reducer(initialState, { type: 'FOO' })).to.equal(initialState)
+  })
+
+  it('does not have referential equality if one of the reducers changes something', () => {
+    const reducer = combineReducers({
+      child1 (state = {}) {
+        return state
+      },
+      child2 (state = { count: 0 }, action) {
+        switch (action.type) {
+          case 'increment':
+            return { count: state.count + 1 }
+          default:
+            return state
+        }
+      },
+      child3 (state = {}) {
+        return state
+      }
+    })
+
+    const initialState = reducer(undefined, '@@INIT')
+    expect(reducer(initialState, { type: 'increment' })).to.not.equal(initialState)
+  })
+
+  it('catches error thrown in reducer when initializing and re-throw', () => {
+    const reducer = combineReducers({
+      throwingReducer () {
+        throw new Error('Error thrown in reducer')
+      }
+    })
+    expect(
+      () => reducer({})
+    ).to.throw(
+      /Error thrown in reducer/
+    )
+  })
+
+  it('ignores all props which are not a function (in production)', () => {
+    global.process.env.NODE_ENV = 'production';
+
+    const reducer = combineReducers({
+      fake: true,
+      broken: 'string',
+      another: { nested: 'object' },
+      stack: (state = []) => state
+    });
+
+    const validReducerKeys = Object.keys(reducer(Immutable({}), { type: 'push' }))
+
+    expect(validReducerKeys).to.deep.equal(['stack'])
+
+    global.process.env.NODE_ENV = undefined
+  })
+
+  it('throws an error if a reducer returns undefined handling an action', () => {
+    const reducer = combineReducers({
+      counter (state = 0, action) {
+        switch (action && action.type) {
+          case 'increment':
+            return state + 1
+          case 'decrement':
+            return state - 1
+          case 'whatever':
+          case null:
+          case undefined:
+            return undefined
+          default:
+            return state
+        }
+      }
+    })
+
+    const state = Immutable({ counter: 0 })
+
+    expect(
+      () => reducer(state, { type: 'whatever' })
+    ).to.throw(
+      /"counter".*"whatever"/
+    )
+    expect(
+      () => reducer(state, null)
+    ).to.throw(
+      /"counter".*an action/
+    )
+    expect(
+      () => reducer(state, {})
+    ).to.throw(
+      /"counter".*an action/
+    )
+  })
+
+  it('throws an error on first call if a reducer returns undefined initializing', () => {
+    const reducer = combineReducers({
+      counter (state, action) {
+        switch (action && action.type) {
+          case 'increment':
+            return state + 1
+          case 'decrement':
+            return state - 1
+          default:
+            return state
+        }
+      }
+    })
+
+    expect(
+      () => reducer(Immutable({}), 'asdf')
+    ).to.throw(
+      /"counter".*initialization/
+    )
+  })
+
+  it('allows a symbol to be used as an action type', () => {
+    const increment = Symbol('INCREMENT')
+
+    const reducer = combineReducers({
+      counter (state = 0, action) {
+        switch (action.type) {
+          case increment:
+            return state + 1
+          default:
+            return state
+        }
+      }
+    })
+
+    expect(
+      reducer(Immutable({ counter: 0 }), { type: increment }).counter
+    ).to.equal(1)
+  })
+
+  it('throws an error on first call if a reducer attempts to handle a private action', () => {
+    const reducer = combineReducers({
+      counter (state, action) {
+        switch (action.type) {
+          case 'increment':
+            return state + 1
+          case 'decrement':
+            return state - 1
+          // Never do this in your code:
+          case '@@redux/INIT':
+            return 0
+          default:
+            return undefined
+        }
+      }
+    })
+
+    expect(() => reducer()).to.throw(
+      /"counter".*private/
+    )
   })
 })


### PR DESCRIPTION
This will align the seamless-immutable implementation of combineReducers with the more robust
version which comes with redux itself. It includes state/reducer validations and throws errors
when things seem awry.