### PR TITLE
Update seamless-immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "react-router-redux": "^4.0.0",
-    "seamless-immutable": "^6.1.0"
+    "seamless-immutable": "^7.1.2"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
This needs an update. That version of immutable is missing some helper methods which make it sort of unusable, e.g. `getIn`.